### PR TITLE
better package.json

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,17 +1,14 @@
 {
   "author": "Thaddee Tyl <thaddee.tyl@gmail.com>",
-  "name": "ScoutCamp",
-  "description": "Boilerplate for easy Web Apps",
+  "name": "camp",
+  "description": "easy webapps",
   "version": "0.0.1",
   "homepage": "http://espadrine.github.com/ScoutCamp/",
   "repository": {
     "type": "git",
     "url": "git://github.com/espadrine/ScoutCamp.git"
   },
-  "main": "lib/camp",
-  "scripts": {
-    "test": "make"
-  },
+  "main": "./camp",
   "engines": {
     "node": ">=0.4.9"
   },


### PR DESCRIPTION
Yope.
- Much better package.json (it only installs the lib/ folder).
- `npm install ../ScoutCamp/lib` now makes sense.
- Installation copies ScoutCamp/lib/\* to <anywhere>/node_modules/camp/\* (including license and scout.js)
- `npm update camp` works.
- `require('camp')` works.
- Doesn't install boilerplate / demos / docs / buildscript though, just the core machinery for easy integration.
- NOT listed in http://search.npmjs.org/ because people should use the boilerplate and buildscript by forking ScoutCamp and using 'make update'. The npm way is for ScoutCamp specialists with very special needs.
