### PR TITLE
Use gzip or deflate compression when possible

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -12,7 +12,8 @@ var EventEmitter = require ('events').EventEmitter,
     p = require('path'),
     fs = require('fs'),
     url = require('url'),
-    qs = require('querystring');
+    qs = require('querystring'),
+    zlib = require('zlib');
 
 
 
@@ -320,9 +321,20 @@ function staticUnit (server) {
         ask.mime(mime['html']);
       }
 
-
       // Connect the output of the file to the network!
-      fs.createReadStream(realpath).pipe(ask.res);
+      var raw = fs.createReadStream(realpath),
+          enc = ask.req.headers['accept-encoding'] || '';
+      
+      // Compress when possible
+      if (enc.match(/\bgzip\b/)) {
+        ask.res.setHeader('content-encoding', 'gzip');
+        raw.pipe(zlib.createGzip()).pipe(ask.res);
+      } else if (enc.match(/\bdeflate\b/)) {
+        ask.res.setHeader('content-encoding', 'deflate');
+        raw.pipe(zlib.createDeflate()).pipe(ask.res);
+      } else {
+        raw.pipe(ask.res);
+      }
     });
   };
 }


### PR DESCRIPTION
Hi @espadrine,

I promised to do this, but didn't think it would be so disappointingly easy. ScoutCamp now supports `gzip` and `deflate` compression, which should give a huge performance boost for large text files.

Cheers,
Jan
