### PR TITLE
Improve HTTPS certificate generation, plus drive-by's and Makefile comments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,10 +107,10 @@ jsmin:
 	  else echo ' `sudo make jsmin`'; fi
 
 https.key:
-	@openssl genrsa -aes256 -out https.key 1024
+	@openssl genrsa -out https.key 4096
 
 https.csr: https.key
-	@openssl req -new -key https.key -out https.csr
+	@openssl req -new -sha256 -key https.key -out https.csr
 
 https.crt: https.key https.csr
 	@openssl x509 -req -days 365 -in https.csr -signkey https.key -out https.crt

--- a/Makefile
+++ b/Makefile
@@ -94,9 +94,9 @@ test:
 	node test/test-api.js
 
 update:
-	@git clone https://github.com/espadrine/sc.git
-	@cp sc/web/js/scout.js ./web/js/scout.js
-	@cp sc/camp/* ./camp/
+	@git clone https://github.com/espadrine/sc
+	@cp sc/web/js/scout.js ./$(WEB)/js/scout.js
+	@cp sc/lib/* ./lib/
 	@cp sc/Makefile .
 	@rm -rf sc/
 
@@ -122,16 +122,16 @@ rmhttps:
 https: https.crt
 
 scout-update:
-	@curl https://raw.github.com/jquery/sizzle/master/sizzle.js > web/js/sizzle.js 2> /dev/null
-	@curl https://raw.github.com/douglascrockford/JSON-js/master/json2.js > web/js/json2.js 2> /dev/null
-	@curl https://raw.github.com/remy/polyfills/master/EventSource.js > web/js/EventSource.js 2> /dev/null
+	@curl https://raw.github.com/jquery/sizzle/master/sizzle.js > $(WEB)/js/sizzle.js 2> /dev/null
+	@curl https://raw.github.com/douglascrockford/JSON-js/master/json2.js > $(WEB)/js/json2.js 2> /dev/null
+	@curl https://raw.github.com/remy/polyfills/master/EventSource.js > $(WEB)/js/EventSource.js 2> /dev/null
 
 scout-build:
 	@for ajsmin in $(JSMIN); do  \
 	  if which $$ajsmin > /dev/null; then chosenjsmin=$$ajsmin; break; fi;  \
 	done;  \
-	cat web/js/sizzle.js web/js/json2.js web/js/EventSource.js web/js/additions.js | $$ajsmin > web/js/scout.js
-	@cp web/js/scout.js .
+	cat $(WEB)/js/sizzle.js $(WEB)/js/json2.js $(WEB)/js/EventSource.js $(WEB)/js/additions.js | $$ajsmin > $(WEB)/js/scout.js
+	@cp $(WEB)/js/scout.js .
 
 help:
 	@cat Makefile | less

--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ the demo!
 
 Versions are tags labeled after the day it was released.
 
-    12.11.10 → january 10th, 2012
+    31.06.28 → june 28th, 2031
 


### PR DESCRIPTION
Hello friend!

I don't think it's useful to encrypt the `https.key` file with AES-256 and passphrase, especially because dealing with a passphrase is hard in Camp. I think that by default, `make https && SECURE=yes make start` fails because Camp feeds the encrypted key directly to Node's TLS module, making it choke.

Also, I bumped the key bits from 1024 to 4096, and forced the CSR digest to be SHA-256 (instead of the default SHA-1 I believe).

Also, I added some comments to the Makefile, and replaced some hard-coded `web/` references with `$(WEB)/` so that the sc-specific commands still work if you rename your `web/` folder.