### PR TITLE
Better path handling

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -10,11 +10,10 @@ var WebSocket = require('ws');
 
 var EventEmitter = require ('events').EventEmitter;
 var inherits = require('util').inherits;
+var fs = require('fs');
 var http = require('http');
 var https = require('https');
 var log = require('multilog');
-var p = require('path');
-var fs = require('fs');
 var url = require('url');
 var zlib = require('zlib');
 var querystring = require('querystring');
@@ -152,6 +151,31 @@ function getQueries(ask, end) {
     }
   }
 }
+
+// Path handling.
+var p = (function() {
+  var path = require('path');
+
+  function normalize (vpath) {
+    // The following features several Windows hacks.
+    var npath = path.normalize(('/' + vpath)
+        .replace(/\\/g,'/').replace(/\/\//g,'/')).replace(/\\/g,'/');
+    //console.log('NORMALIZED PATH OF', vpath, 'IS', npath);
+    return npath;
+  }
+
+  function join (root, vpath) {
+    var apath = path.join(root, normalize(vpath));
+    //console.log('ABSOLUTE PATH OF', vpath, 'IS', apath);
+    return apath;
+  }
+
+  return {
+    normalize: normalize,
+    join: join,
+    extname: path.extname
+  }
+})();
 
 
 


### PR DESCRIPTION
It looks like `p.join(documentRoot, templatePath)` could be improved, so I replaced `var p = require('path')` with a custom closure.

@espadrine please have a look.