### PR TITLE
Add HTTP-method-specific routing helpers

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -451,6 +451,10 @@ An **Augmented Response** is a [ServerResponse][] which also has:
   template.
 - `file(path)`: responds to the request with the contents of the file at `path`,
   on disk under `documentRoot`.
+- `json(data, replacer, space)`: responds to the request with stringified JSON
+  data. Arguments are passed to `JSON.stringify()`, so you can use either
+  `res.json({a: 42})` (minified) or `res.json({a: 42}, null, 2)`
+  (human-readable).
 - `compressed()`: returns a writable stream. All data sent to that stream gets
   compressed and sent as a response.
 

--- a/lib/camp.js
+++ b/lib/camp.js
@@ -108,9 +108,9 @@ function augmentReqRes(req, res, server) {
     });
   };
   // Sending JSON data
-  res.json = function (data) {
+  res.json = function (data, replacer, space) {
     res.setHeader('Content-Type', mime.json);
-    var json = JSON.stringify(data);
+    var json = JSON.stringify(data, replacer, space) + (space ? '\n' : '');
     res.compressed().end(json);
   };
   res.compressed = function() {

--- a/lib/camp.js
+++ b/lib/camp.js
@@ -744,26 +744,51 @@ function Path(matcher) {
   }
 }
 
-// Path unit.
-function pathLikeUnit(serverMethod, statusCode) {
-  statusCode = statusCode || 200;
-  return function unit(server) {
-    var paths = [];
+// Path-like unit.
+//
+// The optional `httpMethods` array allows specifying which HTTP methods should
+// have their own specific helpers like `server.get()`, `server.post()`, etc.
+// Warning: Calling `pathLikeUnit` several times with the same HTTP methods will
+// overwrite any corresponding `server[method]` helpers!
+function pathLikeUnit(serverMethod, statusCode, httpMethods) {
+  httpMethods = httpMethods || [];
+  return function pathLikeUnit(server) {
     var callbacks = [];
 
-    var addPath = function (path, callback) {
-      paths.push(new Path(path));
-      callbacks.push(callback);
+    var addCallback = function (path, callback) {
+      callbacks.push({
+        path: new Path(path),
+        methods: null,
+        callback: callback
+      });
     };
+    server[serverMethod] = addCallback;
 
-    server[serverMethod] = addPath;
+    // HTTP method-specific helpers like server.get(), server.post(), etc.
+    httpMethods.forEach(function (method) {
+      server[method.toLowerCase()] = function (path, callback) {
+        callbacks.push({
+          path: new Path(path),
+          methods: [method],
+          callback: callback
+        });
+      };
+    });
+
     return function pathLayer (req, res, next) {
-      var pathLen = paths.length;
+      var pathLen = callbacks.length;
       var matched = null;
       var cbindex = -1;
       for (var i = 0; i < pathLen; i++) {
-        matched = paths[i].match(req.path);
-        if (matched !== null) { cbindex = i; break; }
+        matched = callbacks[i].path.match(req.path);
+        if (matched == null) {
+          continue;
+        }
+        var methods = callbacks[i].methods;
+        if (methods != null && methods.indexOf(req.method) === -1) {
+          continue;
+        }
+        cbindex = i; break;
       }
       if (cbindex >= 0) {
         getQueries(req, function(err) {
@@ -775,8 +800,9 @@ function pathLikeUnit(serverMethod, statusCode) {
             req.data[key] = matched[key];
           }
           res.statusCode = statusCode;
-          if (callbacks[cbindex] !== undefined) {
-            callbacks[cbindex](req, res);
+          var cb = callbacks[cbindex] && callbacks[cbindex].callback;
+          if (cb != null) {
+            cb(req, res);
           } else {
             res.template(req.data);
           }
@@ -785,7 +811,7 @@ function pathLikeUnit(serverMethod, statusCode) {
     };
   };
 }
-var pathUnit = pathLikeUnit('path');
+var pathUnit = pathLikeUnit('path', 200, http.METHODS);
 var notFoundUnit = pathLikeUnit('notFound', 404);
 
 // Template unit.
@@ -1008,6 +1034,7 @@ exports.socketUnit = socketUnit;
 exports.wsUnit = wsUnit;
 exports.ajaxUnit = ajaxUnit;
 exports.eventSourceUnit = eventSourceUnit;
+exports.pathUnit = pathUnit;
 exports.routeUnit = routeUnit;
 exports.staticUnit = staticUnit;
 exports.notfoundUnit = notfoundUnit;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "devDependencies": {},
   "optionalDependencies": {},
   "engines": {
-    "node": ">=0.10"
+    "node": ">=0.11.8"
   },
   "license": "MIT",
   "directories": {

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -107,7 +107,7 @@ var launchTests = function () {
 
       server.path('json', function (req, res) {
         res.statusCode = 418; // I'm a teapot (see RFC 2324).
-        res.json(data);
+        res.json(data, null, 2);
       });
 
       get('/json', function (res) {
@@ -121,7 +121,7 @@ var launchTests = function () {
         });
         res.on('end', function () {
           t.eq(String(body).trim(), JSON.stringify(data, null, 2),
-            '`res.json(data)` should return human-readable JSON.');
+            '`res.json(data, null, 2)` should return human-readable JSON.');
           next();
         });
       });

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -7,16 +7,28 @@ var t = new Test();
 
 var get = function (path, callback) {
   http.get('http://localhost:' + portNumber + path, callback);
-}
+};
+var post = function (path, postData, contentType, callback) {
+  var options = {
+    hostname: 'localhost',
+    port: portNumber,
+    path: path,
+    method: 'POST'
+  };
+  var req = http.request(options, callback);
+  if (contentType) req.setHeader('Content-Type', contentType);
+  if (postData) req.write(postData);
+  req.end();
+};
 
-var launchTests = function() {
+var launchTests = function () {
   t.seq([
-    function t0(next) {
+    function t0 (next) {
       get('', function (res) {
         t.eq(res.httpVersion, '1.1', "Server must be HTTP 1.1.");
         t.eq(res.headers['transfer-encoding'], 'chunked',
           "Connection should be chunked by default.");
-        res.on('data', function(content) {
+        res.on('data', function (content) {
           t.eq('' + content, '404',
                "Did not receive content of index.html.");
           next();
@@ -24,12 +36,12 @@ var launchTests = function() {
       });
     },
 
-    function t1(next) {
+    function t1 (next) {
       // Using a streamed route.
       // Create a stream out of the following string.
       var template = '{{= text in plain}}\n{{for comment in comments{{\n- {{= comment in plain}}}} }}';
 
-      server.route( /^\/blog$/, function(query, match, end) {
+      server.route( /^\/blog$/, function (query, match, end) {
         end ({
           text: 'My, what a silly blog.',
           comments: ['first comment!', 'second comment…']
@@ -42,10 +54,10 @@ var launchTests = function() {
       // Test that now.
       get('/blog', function (res) {
         var content = '';
-        res.on('data', function(chunk) {
+        res.on('data', function (chunk) {
           content += '' + chunk;
         });
-        res.on('end', function() {
+        res.on('end', function () {
           t.eq(content, 'My, what a silly blog.\n\n- first comment!\n- second comment…',
             "Routing a streamed template should work.");
           next();
@@ -53,7 +65,7 @@ var launchTests = function() {
       });
     },
 
-    function t2(next) {
+    function t2 (next) {
       // Using `sc.path` with/out named non-slash placeholders (i.e. ':foo').
       server.path('foo', function (req, res) {
         res.end('foo');
@@ -90,7 +102,7 @@ var launchTests = function() {
       }); // Mmmh… I love spaghetti!
     },
 
-    function t3(next) {
+    function t3 (next) {
       var data = { message: '☃' };
 
       server.path('json', function (req, res) {
@@ -102,15 +114,67 @@ var launchTests = function() {
         t.eq(res.statusCode, 418,
           'Setting `res.statusCode` before `res.json(data)` should work.');
         t.eq(res.headers['content-type'], mime.json,
-          'Served content type should always be "' + mime.json + '".')
-        res.on('data', function (body) {
-          t.eq(String(body).trim(), JSON.stringify(data),
+          'Served content type should always be "' + mime.json + '".');
+        var body = '';
+        res.on('data', function (chunk) {
+          body += String(chunk);
+        });
+        res.on('end', function () {
+          t.eq(String(body).trim(), JSON.stringify(data, null, 2),
             '`res.json(data)` should return human-readable JSON.');
           next();
         });
       });
+    },
+
+    function t4 (next) {
+      var data = { id: '☃' };
+      var things = {};
+
+      server.get('things/:thing', function (req, res) {
+        var thing = things[req.query.thing];
+        if (!thing) {
+          res.statusCode = 404;
+          res.end('Could not find the thing :(');
+          return;
+        }
+        res.json(thing);
+      });
+
+      server.post('things/:thing', function (req, res) {
+        t.eq(req.headers['content-type'], mime.json,
+          'Request content type should be "' + mime.json + '".');
+        var json = '';
+        req.on('data', function (chunk) {
+          json += String(chunk);
+        });
+        req.on('end', function () {
+          var thing = JSON.parse(json);
+          t.eq(data.id, thing.id,
+            'Handling JSON post data should work.');
+          things[req.query.thing] = thing;
+          res.statusCode = 201; // Created.
+          res.end('Created the thing! :)');
+        });
+      });
+
+      post('/things/snowman', JSON.stringify(data), mime.json, function (res) {
+        t.eq(res.statusCode, 201,
+          'Response status should be 201, not ' + res.statusCode + '.');
+        get('/things/snowman', function (res) {
+          var json = '';
+          res.on('data', function (chunk) {
+            json += String(chunk);
+          });
+          res.on('end', function () {
+            t.eq(data.id, JSON.parse(json).id,
+              'Should receive the original data back.');
+            next();
+          });
+        });
+      });
     }
-  ], function end() {
+  ], function end () {
     t.tldr();
     process.exit(0);
   });
@@ -119,12 +183,12 @@ var launchTests = function() {
 // FIXME: is there a good way to make a server get a port for testing?
 var server;
 var portNumber = 8000;
-var startServer = function() {
+var startServer = function () {
   server = camp.start({port:portNumber, documentRoot:'./test/web'});
   server.on('listening', launchTests);
 };
 var serverStartDomain = require('domain').create();
-serverStartDomain.on('error', function(err) {
+serverStartDomain.on('error', function (err) {
   if (err.code === 'EADDRINUSE') {
     portNumber++;
     serverStartDomain.run(startServer);


### PR DESCRIPTION
The following pull request makes it possible to do stuff like:

```
var camp = require('camp');
var app = camp.start();
app.get('/heeeeeeeey', function (req, res) {
  res.end('hooooooooo');
});
app.post('/secret', function (req, res) {
  console.log('not so secret:', req.data);
  res.end('done');
});
```

Additionally, it makes it possible to do `app.use(middleware)` (aliased to `app.handle(middleware)`). Both features make Camp's API a little bit more like Express's.

@espadrine please take a look.
