### PR TITLE
Fix `camp.path` by making generated RegExps only match entire inputs

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -666,7 +666,7 @@ function escapeRegex(string) {
 function regexFromString(string) {
   var r = /::|\*\*|:[a-zA-Z_]+|\*/g;
   var match;
-  var regexString = '';
+  var regexString = '^';
   var previousIndex = 0;
   var regexKeys = [];
   var starKey = 0;
@@ -692,7 +692,7 @@ function regexFromString(string) {
       previousIndex += matched.length;
     }
   }
-  regexString += escapeRegex(string.slice(previousIndex));
+  regexString += escapeRegex(string.slice(previousIndex)) + '$';
   var regex = new RegExp(regexString);
   regex.keys = regexKeys;
   return regex;

--- a/lib/camp.js
+++ b/lib/camp.js
@@ -351,6 +351,7 @@ function SecureCamp(opts) {
 inherits(SecureCamp, https.Server);
 
 Camp.prototype.handle = SecureCamp.prototype.handle =
+Camp.prototype.use = SecureCamp.prototype.use =
 function handle(fn) {
   this.stack.splice(this.stackInsertion, 0, fn);
   this.stackInsertion++;


### PR DESCRIPTION
The problem:

    server.path('foo/:bar', function (req, res) {
      res.end('bar=' + req.data.bar);
    });
    server.path('foo/:bar/baz', function (req, res) {
      res.end('baz');
    });
    http.get('http://localhost/foo/quux/baz', function (res) {
      res.on('data', function (data) {
        // FIXME: `data` is 'bar=quux' instead of 'baz'.
        // There is no way to get 'baz', the route is unreachable.
      });
    });

The cause: `regexFromString` returns a partially matching regex (without `^` or `$`), so the path `'foo/:bar'` catches anything from `'not/foo/:bar'` to `'foo/:bar/baz'`.

The solution: Make `regexFromString` return a fully matching regex.

I implemented the solution, and contributed a test that fails when the fix is not applied.