### PR TITLE
Fix #47 by comparing `If-Modified-Since` and `stats.mtime` at same precision

### DIFF
--- a/doc/Readme.md
+++ b/doc/Readme.md
@@ -502,6 +502,16 @@ An **Augmented Response** is a [ServerResponse][] which also has:
 - `file(path)`: responds to the request with the contents of the file at `path`,
   on disk under `documentRoot`.
 
+Note: `file(path)` leverages browser caching by comparing `If-Modified-Since`
+request headers against actual file timestamps, and saves time and bandwidth by
+replying "304 Not Modified" with no content to requests where the browser
+already knows the latest version of a file. However, this header is limited to
+second-level precision by specification, so any file changes happening within
+the same second, or within a 2-second window in the case of leap seconds, cause
+a small risk of browsers fetching and caching a stale version of the file in
+between these changes. Such a cached version would remain stale until the next
+file change and subsequent browser request updating the cache.
+
 Additionally, you can set the mime type of the response with
 `req.mime('png')`, for instance.
 

--- a/lib/camp.js
+++ b/lib/camp.js
@@ -636,13 +636,15 @@ function respondWithFile(req, res, path, ifNoFile) {
     }
     res.mime(p.extname(realpath).slice(1));
 
-    // Cache management.
-    if (+(new Date(req.headers['if-modified-since'])) >= +stats.mtime) {
-      res.statusCode = 304;
-      res.end();  // not modified.
+    // Cache management (compare timestamps at second-level precision).
+    var lastModified = Math.floor(stats.mtime / 1000);
+    var since = req.headers['if-modified-since'];
+    if (since && (lastModified <= Math.floor(new Date(since) / 1000))) {
+      res.statusCode = 304; // not modified.
+      res.end();
       return;
     }
-    res.setHeader('Last-Modified', stats.mtime.toGMTString());
+    res.setHeader('Last-Modified', stats.mtime.toUTCString());
 
     // Connect the output of the file to the network!
     var raw = fs.createReadStream(realpath);


### PR DESCRIPTION
Putting the drive-by fix from #48 here.

Addressed https://github.com/espadrine/sc/pull/48#discussion_r83327254

The solution works by applying the same second-truncation that browsers do. This means we suffer from the same caveats browsers do (intra-second file changes, or multiple changes right after a leap second, are edge cases), but every 304 implementation out there does too. I believe it's better to have a "working" 304 implementation with extremely rare caveats, rather than the current 304 implementation that compares second- with millisecond-precision and only works with a probability of 1/1000.
