### PR TITLE
Handle paths with/out slash prefix interchangeably.

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -714,6 +714,9 @@ function Path(matcher) {
       return path.match(matcher);
     };
   } else if (typeof matcher === 'string') {
+    if (matcher[0] !== '/' && matcher[0] !== '*') {
+      matcher = '/' + matcher;
+    }
     if (/[:*]/.test(matcher)) {
       matcher = regexFromString(matcher);
     }
@@ -748,7 +751,7 @@ function pathLikeUnit(serverMethod, statusCode) {
     var callbacks = [];
 
     var addPath = function (path, callback) {
-      paths.push(new Path('/' + path));
+      paths.push(new Path(path));
       callbacks.push(callback);
     };
 


### PR DESCRIPTION
This change allows the following alternatives:

    server.path('hello', function (req, res) { res.end('hi'); });

and

    server.path('/hello', function (req, res) { res.end('hi'); });

which are equivalent.

This is to keep `camp` compatible with [Self API](https://github.com/jankeromnes/selfapi). @espadrine please take a look.