### PR TITLE
Make the Travis build great again

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -198,13 +198,8 @@ function getQueries(req, end) {
           addToQuery(req, fields);
           addToQuery(req, files);
         }
-      }
-      if (err == null) {
-        addToQuery(req, req.fields);
-        addToQuery(req, req.files);
-      }
-      end(err);
-    });
+        end(err);
+      });
 
     } else if (urlencoded.test(contentType)) {
       // URL encoded data.


### PR DESCRIPTION
Commit 3b1ea968f9062e4b003c2cc10651e01134980855 added a syntax error to `camp.js`, and one of the patch hunks looks like an accidental refactor leftover.

Simply reverting the broken hunk should fix the `sc` build again (Travis, please confirm).