### PR TITLE
Don't unescape route URLs

### DIFF
--- a/lib/camp.js
+++ b/lib/camp.js
@@ -45,11 +45,7 @@ function augmentReqRes(req, res, server) {
   req.uri = url.parse(req.url, true);
   // The form is used for multipart data.
   req.form = undefined;
-  try {
-    req.path = decodeURIComponent(req.uri.pathname);
-  } catch(e) {  // Using `escape` should not kill the server.
-    req.path = unescape(req.uri.pathname);
-  }
+  req.path = req.uri.pathname;
   req.query = req.uri.query;
   req.data = req.query;
   // Check (and add fields) for basic authentication.

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -246,7 +246,7 @@ var launchTests = function () {
     },
   ], function end () {
     t.tldr();
-    process.exit(0);
+    t.exit();
   });
 };
 

--- a/test/test-api.js
+++ b/test/test-api.js
@@ -218,6 +218,32 @@ var launchTests = function () {
         next();
       });
     },
+
+    function t7 (next) {
+      server.path('/forward%2Fslash', function (req, res) {
+        res.end('/forward%2Fslash');
+      });
+      server.path('/forward/slash', function (req, res) {
+        res.end('/forward/slash');
+      });
+
+      get('/forward%2Fslash', function(res) {
+        var body = '';
+        res.on('data', function (chunk) { body += String(chunk); });
+        res.on('end', function () {
+          t.eq(body, '/forward%2Fslash', 'Should not unescape forward slash');
+
+          get('/forward/slash', function(res) {
+            body = '';
+            res.on('data', function (chunk) { body += String(chunk); });
+            res.on('end', function () {
+              t.eq(body, '/forward/slash', 'Should not escape forward slash');
+              next();
+            });
+          });
+        });
+      });
+    },
   ], function end () {
     t.tldr();
     process.exit(0);


### PR DESCRIPTION
I would like to do `server.path('/configurations/:file')` where the `:file` parameter could be `.gitconfig` or `.ssh/authorized_keys`. For the latter, that's not possible because even if I escape the requested path to `/configurations/.ssh%2Fauthorized_keys` it still gets unescaped by Camp and results in a 404 (unless I do something like `server.path('/configurations/.ssh/:file')` for every sub-folder I intend to support, which would be tedious).

I'm not sure why URLs are unescaped by default. But when I remove the unescaping code, it works as I expect it to. @espadrine please have a look.